### PR TITLE
Fix setTime method

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -582,10 +582,11 @@
 	CronJob.prototype.addCallback = addCallback;
 
 	CronJob.prototype.setTime = function(time) {
-		if (!(time instanceof CronTime))
+		if (typeof time !== 'object') // crontime is an object...
 			throw new Error('time must be an instance of CronTime.');
 		this.stop();
 		this.cronTime = time;
+		this.start();
 	};
 
 	CronJob.prototype.nextDate = function() {


### PR DESCRIPTION
1. An error occurred when trying:
Example:
```
var time = new cron.CronTime('* * * * * *'); // return an object
job.setTime(time); // time must be an instance of CronTime.
```

2. Start job again